### PR TITLE
Lock transformers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fire
-transformers>=4.28.1
+transformers==4.28.1
 sentencepiece
 tokenizers>=0.13.3
 git+https://github.com/huggingface/peft.git


### PR DESCRIPTION
Newer versions of the transformers library breaks the RoPE implementation required for InvestLM and triggers CUDA device-side assertions.